### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,9 @@
 name: Dependabot auto-approve
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/govindkailas/vault-backup/security/code-scanning/2](https://github.com/govindkailas/vault-backup/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block will explicitly define the minimum permissions required for the workflow to function correctly. Since the workflow involves checking out the repository and merging pull requests, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for enabling auto-merge functionality.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
